### PR TITLE
Allow script to work in Docker

### DIFF
--- a/Runs_Seurat_Clustering.R
+++ b/Runs_Seurat_Clustering.R
@@ -388,7 +388,7 @@ write(file = OutfileCPUusage, x=c(ReportTime))
 ####################################
 outfiles_to_move <- list.files(Tempdir,pattern = paste(PrefixOutfiles, ".SEURAT_", sep=""), full.names = F)
 sapply(outfiles_to_move,FUN=function(eachFile){ 
-  file.rename(from=paste(Tempdir,"/",eachFile,sep=""),to=paste(Outdir,"/SEURAT/",eachFile,sep=""))
+  file.copy(from=paste(Tempdir,"/",eachFile,sep=""),to=paste(Outdir,"/SEURAT/",eachFile,sep=""))
 })
 
 ####################################


### PR DESCRIPTION
Change the R function for copying files from Tempdir to Outdir to file.copy, which is able to copy files across volumes. This allows the script to work in Docker without changing $HOME to the mounted disk.